### PR TITLE
fix size calculation function

### DIFF
--- a/lib/Conversion/ClosureToLLVM/ClosureToLLVM.cpp
+++ b/lib/Conversion/ClosureToLLVM/ClosureToLLVM.cpp
@@ -143,7 +143,7 @@ struct ConvertClosureBoxToLLVM : public ConvertOpToLLVMPattern<closure::BoxOp> {
     static Value getSizeOfType(Type ty, ImplicitLocOpBuilder &rewriter)
     {
         //  https://stackoverflow.com/questions/14608250/how-can-i-find-the-size-of-a-type
-        auto fakeArray = rewriter.create<LLVM::UndefOp>(ptrType(ty));
+        auto fakeArray = rewriter.create<LLVM::NullOp>(ptrType(ty));
 
         auto gep = rewriter.create<LLVM::GEPOp>(
             ptrType(ty),


### PR DESCRIPTION
This fixes a bug where the size calculation for types used a GEP on an undef value instead of a NULL value.
 